### PR TITLE
Fix copy success message typo

### DIFF
--- a/lib/feature/color/ui/component/palette.dart
+++ b/lib/feature/color/ui/component/palette.dart
@@ -135,7 +135,7 @@ class _PaletteState extends ConsumerState<Palette> {
         // スナックバーを表示する
         ref.showSnakBar(
           SnackBar(
-            content: Text('$hex Coppied!'),
+            content: Text('$hex Copied!'),
             width: snackBarWidth,
           ),
         );

--- a/lib/feature/color/ui/component/tonal_palette.dart
+++ b/lib/feature/color/ui/component/tonal_palette.dart
@@ -209,7 +209,7 @@ class _PrimaryCircleColor extends ConsumerWidget {
           // スナックバーを表示する
           ref.showSnakBar(
             SnackBar(
-              content: Text('$hex Coppied!'),
+              content: Text('$hex Copied!'),
               width: snackBarWidth,
             ),
           );


### PR DESCRIPTION
## Summary
- fix 'Coppied!' typo in palette snack bar message
- fix same typo in tonal palette snack bar message

## Testing
- `dart format lib/feature/color/ui/component/palette.dart lib/feature/color/ui/component/tonal_palette.dart` *(fails: command not found)*
- `flutter format lib/feature/color/ui/component/palette.dart lib/feature/color/ui/component/tonal_palette.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a47c0618832da6192ff7d72a35a3