### PR TITLE
Handle missing Flutter version asset

### DIFF
--- a/lib/feature/home/ui/page/component/copy_right.dart
+++ b/lib/feature/home/ui/page/component/copy_right.dart
@@ -10,10 +10,15 @@ class CopyRightText extends StatefulWidget {
 }
 
 class _CopyRightTextState extends State<CopyRightText> {
-  Future<String> _getFlutterVersion() async {
-    final flutterVersion =
-        await DefaultAssetBundle.of(context).loadString('.dart_tool/version');
-    return flutterVersion;
+  Future<String?> _getFlutterVersion() async {
+    try {
+      final flutterVersion = await DefaultAssetBundle.of(context)
+          .loadString('.dart_tool/version');
+      return flutterVersion;
+    } catch (_) {
+      // The asset might not be available in packaged builds.
+      return null;
+    }
   }
 
   @override
@@ -32,8 +37,9 @@ class _CopyRightTextState extends State<CopyRightText> {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                if (flutterVersion != null)
-                  Text('powered by Flutter $flutterVersion '),
+                Text(
+                  'powered by Flutter${flutterVersion != null ? ' $flutterVersion' : ''} ',
+                ),
                 const Text('(C) 2023 susatthi.'),
               ],
             ),


### PR DESCRIPTION
## Summary
- make `CopyRightText` resilient if `.dart_tool/version` is missing

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ad5d2468832da3ecc4ceeec98fb6